### PR TITLE
feat: update node version to 20.x in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "tailwindcss": "3.4.13",
     "typescript": "5.5.4",
     "vitest": "2.1.2"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }


### PR DESCRIPTION
### Description

This pull request specifies the Node.js version to be used for the project by adding an `engines` field in `package.json`.

The `engines` field now contains:

```json
"engines": {
  "node": "20.x"
}
```

This change ensures that Vercel, or any other environment, uses Node.js version 20.x to run the project, maintaining consistency across deployments.

